### PR TITLE
Properly activate installed version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,7 @@ install_emsdk() {
     local install_path=$3
 
     "${install_path}/emsdk" install "${version}"
-    "${install_path}/emsdk" activate --embedded
+    "${install_path}/emsdk" activate "${version}"
     source "${install_path}/emsdk_env.sh"
 }
 


### PR DESCRIPTION
PR to answer https://github.com/RobLoach/asdf-emsdk/issues/5#issuecomment-678462169

`--embedded` is not needed because: `embedded mode is now the only mode available`
you have to specify version because: `No tools/SDKs specified to activate!`

Checked with `esdk` version `2.0.0`