### PR TITLE
feat(exec-env): set non-legacy environment variables

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -19,11 +19,17 @@ if [ -n "$ASDF_INSTALL_PATH" ]; then
   if [ -z "$LLVM_ROOT" ]; then
     export LLVM_ROOT="${ASDF_INSTALL_PATH}/upstream/bin"
   fi
+  if [ -z "$EM_LLVM_ROOT" ]; then
+    export EM_LLVM_ROOT="${ASDF_INSTALL_PATH}/upstream/bin"
+  fi
   if [ -z "$BINARYEN" ]; then
     export BINARYEN="${ASDF_INSTALL_PATH}/upstream"
   fi
   if [ -z "$BINARYEN_ROOT" ]; then
     export BINARYEN_ROOT="${ASDF_INSTALL_PATH}/upstream"
+  fi
+  if [ -z "$EM_BINARYEN_ROOT" ]; then
+    export EM_BINARYEN_ROOT="${ASDF_INSTALL_PATH}/upstream"
   fi
 
   if [ -z "$EMSDK_NODE" ]; then


### PR DESCRIPTION
When I tried using `emsdk` installed by the plugin to install the latest version of `emcc` (3.1.44), I noticed warnings being printed for legacy environment variables being used. Setting the recommended environment variables based on the old ones set by the plugin does the trick.

```console
$ emcc --check
legacy environment variable found: `LLVM`.  Please switch to using `EM_LLVM_ROOT` instead`
legacy environment variable found: `BINARYEN`.  Please switch to using `EM_BINARYEN_ROOT` instead`
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.44 (bec42dac7873903d09d713963e34020c22a8bd2d)
shared:INFO: (Emscripten: Running sanity checks)
$ EM_LLVM_ROOT=$LLVM EM_BINARYEN_ROOT=$BINARYEN emcc --check
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.44 (bec42dac7873903d09d713963e34020c22a8bd2d)
shared:INFO: (Emscripten: Running sanity checks)
```